### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
   


### PR DESCRIPTION
Potential fix for [https://github.com/AXIS5hacker/DNX-Note-Width-Changer/security/code-scanning/1](https://github.com/AXIS5hacker/DNX-Note-Width-Changer/security/code-scanning/1)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best single change (without altering functionality): add workflow-level permissions with `contents: read` near the top-level keys (`name`, `on`, `jobs`). This satisfies CodeQL’s recommendation and is sufficient for `actions/checkout` and the shown build steps. No new imports, methods, or dependencies are needed.

Edit file:
- `.github/workflows/build.yml`
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it after the `on:` trigger block and before `jobs:` (or equivalently at top-level elsewhere).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
